### PR TITLE
[Issue28] instantiate plugins that are builtin or already installed, otherwise use the BasePlugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The format of `eds.yml`:
 
 ```yaml
 version:
-includes:
+include:
 plugins:
     - id:
       name:

--- a/eds/event.py
+++ b/eds/event.py
@@ -20,8 +20,12 @@ class Event():
             project_name (str): Project name.
             project_version (str): Project version.
         """
+        # todo:
+        #   these *_built values need to be determined by the worker
+        #   will be implemented in a forthcoming BaseWorker class.
         self._eds_built = eds_built
         self._eds_plugins_built = eds_plugins_built
+
         self._url = url
         self._project_name = project_name
         self._project_version = project_version

--- a/eds/extend.py
+++ b/eds/extend.py
@@ -121,3 +121,16 @@ def get_plugins(group: str, project: str = None) -> Dict:
         Dict: Dict of plugins.
     """
     return _get_plugins(group, project=project)
+
+
+def is_installed(pip_install_requirement: str) -> bool:
+    """Whether a pip install requirement is installed.
+
+    Args:
+        pip_install_requirement (str): pip install requirement.
+
+    Returns:
+        bool: Whether a pip install requirement is installed.
+    """
+    # todo: implement using https://github.com/pypa/pip/blob/main/src/pip/_internal/req/req_install.py#L392
+    raise NotImplementedError()

--- a/eds/project.py
+++ b/eds/project.py
@@ -4,10 +4,11 @@ from copy import deepcopy
 from typing import Dict, List
 
 from eds.event import Event
-from eds.extend import get_plugin
+from eds.extend import get_plugin, is_installed
 from eds.exception import DuplicateIncludeError
 from eds.interfaces.plugin import Plugin
 from eds.interfaces.pipeline import Pipeline
+from eds.plugin import BasePlugin
 
 
 EDS_YML_FILE: str = 'eds.yml'
@@ -31,16 +32,14 @@ class Project:
         """
         self._event = event
         self._yaml = event.eds_yaml
+        self._plugins = []
+        self._lookup = lookup if lookup is not None else {}
         self._validate_schema()
-        if lookup is None:
-            self._lookup = {}
-            self._plugins = self._get_plugins()
-            [self._apply_inheritance(p) for p in self._plugins]
-        elif self._event.url in lookup:
+        if self._event.url in self._lookup:
             raise DuplicateIncludeError("%s has already been included" % self._event.url)
-        else:
-            self._lookup = lookup
         self._lookup[self._event.url] = {}
+        self._discover_plugins()
+        [self._apply_inheritance(p) for p in self._plugins]
 
     def _validate_schema(self) -> None:
         """Validate 'self._yaml' using schema in `Project.schema`."""
@@ -59,23 +58,28 @@ class Project:
             includes.append(Project(event, self._lookup))
         return includes
 
-    def _get_plugins(self) -> List[Plugin]:
+    def _discover_plugins(self) -> List[Plugin]:
         """Recursively discover all the plugins.
 
         Returns:
             List[Plugin]: The list of discovered plugins.
         """
-        plugins = []
         for include in self._get_includes():
-            plugins += include._get_plugins()
+            self._plugins += include.plugins
         for plugin_yaml in self._yaml['plugins']:
-            plugin = get_plugin(plugin_yaml['type'], plugin_yaml['name'])(plugin_yaml)
+            # If plugin is builtin or already installed, then it can be
+            # instantiated. Otherwise, we will use the BasePlugin, and the
+            # actual plugin will be instantiated in a future discovery after
+            # worker performs the installation.
+            if 'version' not in plugin_yaml or is_installed(plugin_yaml['version']):
+                plugin = get_plugin(plugin_yaml['type'], plugin_yaml['name'])(plugin_yaml)
+            else:
+                plugin = BasePlugin(plugin_yaml)
             self._lookup[self._event.url][plugin.id] = plugin
             for descendant in plugin.descendants:
                 self._lookup[self._event.url][descendant.id] = descendant
-                plugins.append(descendant)
-            plugins.append(plugin)
-        return plugins
+                self._plugins.append(descendant)
+            self._plugins.append(plugin)
 
     def _apply_inheritance(self, plugin: Plugin) -> None:
         """Gather parent properties recursively.  Mark parent plugins as overridden.
@@ -103,12 +107,12 @@ class Project:
 
     @property
     def plugin_versions(self) -> List[str]:
-        """The list of plugin pip install requirments.
+        """The list of plugin pip install requirements.
 
         Returns:
             List[str]: The list of plugin pip install requirments.
         """
-        return [p.yaml['version'] for p in self._plugins if not p.overridden]
+        return [p.yaml['version'] for p in self._plugins if 'version' in p.yaml and not p.overridden]
 
     @property
     def pipelines(self) -> List[Pipeline]:


### PR DESCRIPTION
For #28 

If a plugin is builtin or already installed, then it can be instantiated directly, Otherwise, we will use the BasePlugin, and the actual plugin class will be instantiated in a future discovery after the EDS worker performs the installation.  This is necessary, since we don't assume EDS comes with every plugin built in.  Part of the job of EDS, is to install them for you.

PR contains two "todo"s which will be handled in a subsequent PR.

