### PR TITLE
implement installation checker

### DIFF
--- a/eds/extend.py
+++ b/eds/extend.py
@@ -1,5 +1,7 @@
 
 from __future__ import annotations
+from pip._internal.req import InstallRequirement
+from pip._vendor.packaging.requirements import Requirement
 import pkg_resources
 from typing import Dict, Iterator
 
@@ -132,5 +134,7 @@ def is_installed(pip_install_requirement: str) -> bool:
     Returns:
         bool: Whether a pip install requirement is installed.
     """
-    # todo: implement using https://github.com/pypa/pip/blob/main/src/pip/_internal/req/req_install.py#L392
-    raise NotImplementedError()
+    req = Requirement(pip_install_requirement)
+    install_req = InstallRequirement(req, None)
+    install_req.check_if_exists(use_user_site=False)
+    return install_req.satisfied_by is not None

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         'click',
         'setuptools',
+        'pip'
     ],
     entry_points={
         'console_scripts': [

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -2,7 +2,7 @@
 import pkg_resources
 import pytest
 
-from eds.extend import _get_plugins, get_plugins, get_plugin
+from eds.extend import _get_plugins, get_plugins, get_plugin, is_installed
 from eds.exception import (PluginNameNotFoundError, NoPluginsFoundError,
                            DuplicatePluginError, PluginNameMismatchError,
                            PluginNoNameAttributeError, PluginInterfaceNotImplementedError,
@@ -109,3 +109,10 @@ def test__get_plugins_interface_not_implemented(monkeypatch):
     patch_working_set(monkeypatch, 'PipelinePlugin')
     with pytest.raises(PluginInterfaceNotImplementedError):
         _get_plugins('eds.config')
+
+def test_is_installed_satisfied():
+    assert is_installed('eds')
+
+def test_is_installed_not_satisfied():
+    assert not is_installed('no_eds_is_installed')
+


### PR DESCRIPTION
the `eds.yml` format is designed to allow users to specify their desired versions of EDS and EDS plugins using version formats that pip supports.  the EDS worker has to determine up front what needs to be installed, so this PR implements an `is_installed` function using pip itself to determine if a version requirement is satisfied.

